### PR TITLE
add workflow to run tests during a PR

### DIFF
--- a/.github/workflows/.#test.yml
+++ b/.github/workflows/.#test.yml
@@ -1,0 +1,1 @@
+ebarylko@Eitans-MBP.local.14394

--- a/.github/workflows/.#test.yml
+++ b/.github/workflows/.#test.yml
@@ -1,1 +1,0 @@
-ebarylko@Eitans-MBP.local.14394

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Cache node modules
+        id: cache-npm
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        name: List the state of node modules
+        continue-on-error: true
+        run: npm list
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+
       - name: Install dependencies
         run: npm install
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Run tests
+
+on: [pull_request]
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm run test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+
+The current state of the workflow ![test workflow](https://github.com/ai-ed/ai-ed.github.io/actions/workflows/test.yml/badge.svg)
+
 # ai-ed.github.io
 # AI Education Resources
 
@@ -91,4 +94,3 @@ To do this you need to do the following:
 
 After this you will either see a message that the tests passed or that they failed.
 
-![test workflow](https://github.com/ai-ed/ai-ed.github.io/actions/workflows/test.yml/badge.svg)

--- a/README.md
+++ b/README.md
@@ -79,3 +79,16 @@ After you finish editing the title and body, submit the PR.
 * Use NIT to indicate the comment is a suggestion but not a must
 * Use Squash option when merging
 * Delete the branch afterwards
+
+
+## Checking the Github action locally
+
+Instead of doing a PR and checking the result of the workflow then, you can run the workflow locally to confirm it works before making the PR.
+
+To do this you need to do the following:
+* Install [act](https://github.com/nektos/act). 
+* Run `act pull_request`
+
+After this you will either see a message that the tests passed or that they failed.
+
+![test workflow](https://github.com/ai-ed/ai-ed.github.io/actions/workflows/test.yml/badge.svg)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
     "type": "module",
     "scripts": {
         "start": "browser-sync start --server --files='**/*' ",
-        "test": "npx jest --watchAll"
+        "test:watch": "npx jest --watchAll",
+        "test": "npx jest"
     },
     "devDependencies": {
         "@babel/preset-env": "^7.22.9",


### PR DESCRIPTION
## Summary

When a PR is created, a Github workflow will be run and will show whether the tests passed or failed

closes #12

## Changes

### README.md
* Added section about running workflow locally

### package.json
* Added `test:watch` script which runs the tests continuously
* Added `test` script which runs the tests once

### .github/workflows/test.yml
* Added a workflow which sets up node and runs the tests

