### PR TITLE
Modify the readme to include the file structure of the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Which is an array of JavaScript Objects containing the following fields:
 
 ### File structure
 
-Because the website uses [GitHub pages](https://pages.github.com/) for serving the site we decided to use [Jekyll](https://jekyllrb.com/) to generate the site. `Jekyll` is the tool used by GH pages and doesn't need extra setup.
+Because the website uses [GitHub pages](https://pages.github.com/) for serving the site we decided to use _Jekyll_ to generate the site. `Jekyll` is the tool used by GH pages and doesn't need extra setup.
 
 ```
 .
@@ -77,7 +77,7 @@ The _Jekyll_ server will then copy everything under `website` (ignoring all the 
 
 #### Creating HTML pages
 
-Jekyll will convert all the markdown files into HTML. To create an HTML page create a markdown file (.md) and add [front matter](https://jekyllrb.com/docs/front-matter/) to the file to specify the a layout. Here is an example using the _default_ layout:
+_Jekyll_ will convert all the markdown files into HTML. To create an HTML page create a markdown file (.md) and add [front matter](https://jekyllrb.com/docs/front-matter/) to the file to specify the a layout. Here is an example using the _default_ layout:
 
 ```md
 ---

--- a/README.md
+++ b/README.md
@@ -38,6 +38,31 @@ Which is an array of JavaScript Objects containing the following fields:
 * Install [ruby](https://www.ruby-lang.org/en/) using [rbenv](https://github.com/rbenv/rbenv)
 * Install [bundler](https://bundler.io/) by running `gem install bundler`
 
+### File structure
+
+Because the website uses [GitHub pages](https://pages.github.com/) for serving the site we decided to use [Jekyll](https://jekyllrb.com/) to generate the site. `Jekyll` is the tool used by GH pages and doesn't need extra setup.
+
+```
+.
+├── Gemfile                   # Dependencies list for Ruby
+├── Gemfile.lock              # Lock file for Ruby dependencies
+├── Procfile                  # Foreman uses the file to start Jekyll and Webpack to serve the files and watch
+├── README.md
+├── _config.yml               # Configuration for Jekyll
+├── babel.config.json         # Babel configuration for Webpack
+├── jest.config.js            # Configuration to run tests with jest
+├── package.json              # Node dependencies
+├── package-lock.json         # Lock file for Node dependencies
+├── src                       # Javascript source files (used by Webpack to compile into website/dist)
+├── tests                     # Unit tests and acceptance tests
+├── webpack.config.cjs        # Configuration for Webpack to know where to output the compiled files, etc...
+└── website                   # Contains all the website files (.md files, etc)
+    ├── _layouts              # Jekyll uses the folder for [layouts](https://jekyllrb.com/docs/step-by-step/04-layouts/) for HTML pages
+    ├── dist                  # Webpack compiles all the JS into this folder
+    ├── resources.json        # JSON file with all the resources to show
+    └── static                # Static assets folder (images, svg, css, etc)
+```
+
 ### Serving site on watch mode
 
 The following commands will install the node and ruby dependencies.

--- a/README.md
+++ b/README.md
@@ -70,9 +70,24 @@ The following commands will install the node and ruby dependencies.
 * Run `npm install`
 * Run `bundle`
 
-The next command will serve the site using _Jekyll_ at `http://localhost:3000/` and will update the browser when any changes are made.
+The next command will have [webpack](https://webpack.js.org/) continuously compile the files and output them in `website/dist`, and will start the Jekyll server at `http://localhost:3000/`.
+The _Jekyll_ server will then copy everything under `website` (ignoring all the folders that start with `_` like `_layouts`) to the `_site` folder and serve the files from there. It will also update the browser when the files have changed.
 
 * Run `npm run start`
+
+#### Creating HTML pages
+
+Jekyll will convert all the markdown files into HTML. To create an HTML page create a markdown file (.md) and add [front matter](https://jekyllrb.com/docs/front-matter/) to the file to specify the a layout. Here is an example using the _default_ layout:
+
+```md
+---
+layout: default
+---
+<div>
+  some more info here
+</div>
+```
+Layouts help avoid repeating code in each HTML. Please take a look a the _Jekyll_ [layouts](https://jekyllrb.com/docs/step-by-step/04-layouts/) information for more details.
 
 ### Testing
 


### PR DESCRIPTION
## Summary

The README now includes a section about the file structure of the repository and a note on what each file/repository is for

closes #37

## Changes

### README.md
* Added section on creating an html page with [Jekyll](https://jekyllrb.com/)
* Added a section on the files/directories in the repository and a note on what each one is for

